### PR TITLE
don't crash when creating multi-layer directories

### DIFF
--- a/gdrivefs/core.py
+++ b/gdrivefs/core.py
@@ -116,7 +116,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
         if create_parents and self._parent(path):
             self.makedirs(self._parent(path), exist_ok=True)
         parent_id = self.path_to_file_id(self._parent(path))
-        meta = {"name": path.split("/", 1)[-1],
+        meta = {"name": path.rstrip("/").rsplit("/", 1)[-1],
                 'mimeType': DIR_MIME_TYPE,
                 "parents": [parent_id]}
         self.service.create(body=meta).execute()

--- a/gdrivefs/tests/test_core.py
+++ b/gdrivefs/tests/test_core.py
@@ -21,7 +21,6 @@ def creds():
         except IOError:
             pass
 
-
 def test_simple(creds):
     fs = gdrivefs.GoogleDriveFileSystem(token='cache', tokens_file=creds)
     assert fs.ls("")
@@ -30,3 +29,17 @@ def test_simple(creds):
     with fs.open(fn, 'wb') as f:
         f.write(data)
     assert fs.cat(fn) == data
+
+def test_create_directory(creds):
+    fs = gdrivefs.GoogleDriveFileSystem(token='cache', tokens_file=creds)
+    fs.makedirs(test_dir + "/data")
+    fs.makedirs(test_dir + "/data/bar/baz")
+
+    assert fs.exists(test_dir + "/data")
+    assert fs.exists(test_dir + "/data/bar")
+    assert fs.exists(test_dir + "/data/bar/baz")
+
+    data = b"intermediate path"
+    with fs.open(test_dir + "/data/bar/test", "wb") as stream:
+        stream.write(data)
+    assert fs.cat(test_dir + "/data/bar/test") == data


### PR DESCRIPTION
simple reproducer;
```
import gdrivefs
import uuid

directory = str(uuid.uuid4())

fs = gdrivefs.GoogleDriveFileSystem(token="cache")
fs.makedirs(f"{directory}/data")
fs.makedirs(f"{directory}/data/bar/baz")
```

```
Traceback (most recent call last):
  File "t.py", line 8, in <module>
    fs.makedirs(f"{directory}/data/bar/baz")
  File "/home/isidentical/gdrivefs/gdrivefs/core.py", line 133, in makedirs
    self.mkdir(path, create_parents=False)
  File "/home/isidentical/gdrivefs/gdrivefs/core.py", line 118, in mkdir
    parent_id = self.path_to_file_id(self._parent(path))
  File "/home/isidentical/gdrivefs/gdrivefs/core.py", line 218, in path_to_file_id
    return self.path_to_file_id(sub_path, parent=top_file_id,
  File "/home/isidentical/gdrivefs/gdrivefs/core.py", line 218, in path_to_file_id
    return self.path_to_file_id(sub_path, parent=top_file_id,
  File "/home/isidentical/gdrivefs/gdrivefs/core.py", line 212, in path_to_file_id
    top_file_id = self._get_directory_child_by_name(items[0], parent,
  File "/home/isidentical/gdrivefs/gdrivefs/core.py", line 230, in _get_directory_child_by_name
    raise FileNotFoundError(
FileNotFoundError: Directory 1DKXg2ypWI0550aD6h3D7SLMXEQXE5SdZ has no child named bar
```
I also included an `.rstrip()` call, since when doing `mkdir("foo/bar/baz/")` it actually creates another directory with a trailing slash. 